### PR TITLE
Remove alarm border from slits combo button

### DIFF
--- a/bob/slits/slit-4axis.bob
+++ b/bob/slits/slit-4axis.bob
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--Saved on 2026-01-19 15:36:22 by ryi58813-->
+<!--Saved on 2026-01-20 14:55:06 by ryi58813-->
 <display version="2.0.0">
   <name>slits-4axis</name>
   <widget type="embedded" version="2.0.0">
@@ -34,6 +34,7 @@
       <font family="Liberation Sans" style="BOLD" size="16.0">
       </font>
     </font>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
     <items>
       <item>Individual Blades</item>
       <item>Size and Center</item>


### PR DESCRIPTION
It uses a local PV to determine the embedded screen, but this is not initialized before pressing a button. Removing the alarm border avoids this pink border on first load.