### PR TITLE
ADAravis_detail.bob widget widths and x coords fixed

### DIFF
--- a/bob/ADAravis/ADAravis_detail.bob
+++ b/bob/ADAravis/ADAravis_detail.bob
@@ -3,7 +3,7 @@
 <display version="2.0.0">
   <name>ADAravis Camera</name>
   <y use_class="true">0</y>
-  <width>862</width>
+  <width>1609</width>
   <height>916</height>
   <background_color use_class="true">
     <color name="Read_Background" red="240" green="240" blue="240">
@@ -15,7 +15,7 @@
     <name>Title</name>
     <class>TITLE</class>
     <text>ADAravis Camera</text>
-    <width>862</width>
+    <width>1609</width>
     <height>26</height>
     <font use_class="true">
       <font family="Arial" style="BOLD" size="32.0">
@@ -36,9 +36,9 @@
   </widget>
   <widget type="group" version="3.0.0">
     <name>AD Aravis</name>
-    <x>4</x>
+    <x>5</x>
     <y>30</y>
-    <width>282</width>
+    <width>396</width>
     <height>318</height>
     <style use_class="true">0</style>
     <font use_class="true">
@@ -57,7 +57,7 @@
     <widget type="label" version="2.0.0">
       <name>Label</name>
       <text>AR Frames Completed</text>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -79,8 +79,8 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)ARFramesCompleted</pv_name>
-      <x>124</x>
-      <width>124</width>
+      <x>150</x>
+      <width>205</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -104,7 +104,7 @@
       <name>Label</name>
       <text>AR Frame Failures</text>
       <y>24</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -126,9 +126,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)ARFrameFailures</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>24</y>
-      <width>124</width>
+      <width>205</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -152,7 +152,7 @@
       <name>Label</name>
       <text>AR Frame Underruns</text>
       <y>48</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -174,9 +174,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)ARFrameUnderruns</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>48</y>
-      <width>124</width>
+      <width>205</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -200,7 +200,7 @@
       <name>Label</name>
       <text>AR Missing Packets</text>
       <y>72</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -222,9 +222,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)ARMissingPackets</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>72</y>
-      <width>124</width>
+      <width>205</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -248,7 +248,7 @@
       <name>Label</name>
       <text>AR Resent Packets</text>
       <y>96</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -270,9 +270,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)ARResentPackets</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>96</y>
-      <width>124</width>
+      <width>205</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -296,7 +296,7 @@
       <name>Label</name>
       <text>AR Packet Resend Enable</text>
       <y>120</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -318,9 +318,9 @@
     <widget type="combo" version="2.0.0">
       <name>ComboBox</name>
       <pv_name>$(P)$(R)ARPacketResendEnable</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>120</y>
-      <width>124</width>
+      <width>205</width>
       <height>20</height>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
@@ -339,7 +339,7 @@
       <name>Label</name>
       <text>AR Packet Timeout</text>
       <y>144</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -361,9 +361,9 @@
     <widget type="textentry" version="3.0.0">
       <name>TextEntry</name>
       <pv_name>$(P)$(R)ARPacketTimeout</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>144</y>
-      <width>124</width>
+      <width>205</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -391,7 +391,7 @@
       <name>Label</name>
       <text>AR Frame Retention</text>
       <y>168</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -413,9 +413,9 @@
     <widget type="textentry" version="3.0.0">
       <name>TextEntry</name>
       <pv_name>$(P)$(R)ARFrameRetention</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>168</y>
-      <width>124</width>
+      <width>205</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -443,7 +443,7 @@
       <name>Label</name>
       <text>AR Reset Camera</text>
       <y>192</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -465,9 +465,9 @@
     <widget type="textentry" version="3.0.0">
       <name>TextEntry</name>
       <pv_name>$(P)$(R)ARResetCamera</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>192</y>
-      <width>124</width>
+      <width>205</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -495,7 +495,7 @@
       <name>Label</name>
       <text>AR Convert Pixel Format</text>
       <y>216</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -517,9 +517,9 @@
     <widget type="combo" version="2.0.0">
       <name>ComboBox</name>
       <pv_name>$(P)$(R)ARConvertPixelFormat</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>216</y>
-      <width>60</width>
+      <width>100</width>
       <height>20</height>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
@@ -537,9 +537,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)ARConvertPixelFormat_RBV</pv_name>
-      <x>188</x>
+      <x>255</x>
       <y>216</y>
-      <width>60</width>
+      <width>100</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -563,7 +563,7 @@
       <name>Label</name>
       <text>AR Shift Dir</text>
       <y>240</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -585,9 +585,9 @@
     <widget type="combo" version="2.0.0">
       <name>ComboBox</name>
       <pv_name>$(P)$(R)ARShiftDir</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>240</y>
-      <width>60</width>
+      <width>100</width>
       <height>20</height>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
@@ -605,9 +605,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)ARShiftDir_RBV</pv_name>
-      <x>188</x>
+      <x>255</x>
       <y>240</y>
-      <width>60</width>
+      <width>100</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -631,7 +631,7 @@
       <name>Label</name>
       <text>AR Shift Bits</text>
       <y>264</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -653,9 +653,9 @@
     <widget type="combo" version="2.0.0">
       <name>ComboBox</name>
       <pv_name>$(P)$(R)ARShiftBits</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>264</y>
-      <width>60</width>
+      <width>100</width>
       <height>20</height>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
@@ -673,9 +673,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)ARShiftBits_RBV</pv_name>
-      <x>188</x>
+      <x>255</x>
       <y>264</y>
-      <width>60</width>
+      <width>100</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -698,9 +698,9 @@
   </widget>
   <widget type="group" version="3.0.0">
     <name>arvFeature Ungrouped</name>
-    <x>4</x>
+    <x>5</x>
     <y>352</y>
-    <width>282</width>
+    <width>396</width>
     <height>54</height>
     <style use_class="true">0</style>
     <font use_class="true">
@@ -719,7 +719,7 @@
     <widget type="label" version="2.0.0">
       <name>Label</name>
       <text>AR Connect Camera</text>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -741,8 +741,8 @@
     <widget type="textentry" version="3.0.0">
       <name>TextEntry</name>
       <pv_name>$(P)$(R)ARConnectCamera</pv_name>
-      <x>124</x>
-      <width>124</width>
+      <x>150</x>
+      <width>205</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -769,9 +769,9 @@
   </widget>
   <widget type="group" version="3.0.0">
     <name>AD Collect</name>
-    <x>4</x>
+    <x>5</x>
     <y>410</y>
-    <width>282</width>
+    <width>396</width>
     <height>390</height>
     <style use_class="true">0</style>
     <font use_class="true">
@@ -790,7 +790,7 @@
     <widget type="label" version="2.0.0">
       <name>Label</name>
       <text>Acquire Time</text>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -812,8 +812,8 @@
     <widget type="textentry" version="3.0.0">
       <name>TextEntry</name>
       <pv_name>$(P)$(R)AcquireTime</pv_name>
-      <x>124</x>
-      <width>60</width>
+      <x>150</x>
+      <width>100</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -840,8 +840,8 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)AcquireTime_RBV</pv_name>
-      <x>188</x>
-      <width>60</width>
+      <x>255</x>
+      <width>100</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -865,7 +865,7 @@
       <name>Label</name>
       <text>Acquire Period</text>
       <y>24</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -887,9 +887,9 @@
     <widget type="textentry" version="3.0.0">
       <name>TextEntry</name>
       <pv_name>$(P)$(R)AcquirePeriod</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>24</y>
-      <width>60</width>
+      <width>100</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -916,9 +916,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)AcquirePeriod_RBV</pv_name>
-      <x>188</x>
+      <x>255</x>
       <y>24</y>
-      <width>60</width>
+      <width>100</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -942,7 +942,7 @@
       <name>Label</name>
       <text>Num Images Counter</text>
       <y>48</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -964,9 +964,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)NumImagesCounter_RBV</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>48</y>
-      <width>124</width>
+      <width>205</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -990,7 +990,7 @@
       <name>Label</name>
       <text>Num Images</text>
       <y>72</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -1012,9 +1012,9 @@
     <widget type="textentry" version="3.0.0">
       <name>TextEntry</name>
       <pv_name>$(P)$(R)NumImages</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>72</y>
-      <width>60</width>
+      <width>100</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -1041,9 +1041,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)NumImages_RBV</pv_name>
-      <x>188</x>
+      <x>255</x>
       <y>72</y>
-      <width>60</width>
+      <width>100</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -1067,7 +1067,7 @@
       <name>Label</name>
       <text>Num Exposures</text>
       <y>96</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -1089,9 +1089,9 @@
     <widget type="textentry" version="3.0.0">
       <name>TextEntry</name>
       <pv_name>$(P)$(R)NumExposures</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>96</y>
-      <width>60</width>
+      <width>100</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -1118,9 +1118,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)NumExposures_RBV</pv_name>
-      <x>188</x>
+      <x>255</x>
       <y>96</y>
-      <width>60</width>
+      <width>100</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -1144,7 +1144,7 @@
       <name>Label</name>
       <text>Image Mode</text>
       <y>120</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -1166,9 +1166,9 @@
     <widget type="combo" version="2.0.0">
       <name>ComboBox</name>
       <pv_name>$(P)$(R)ImageMode</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>120</y>
-      <width>60</width>
+      <width>100</width>
       <height>20</height>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
@@ -1186,9 +1186,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)ImageMode_RBV</pv_name>
-      <x>188</x>
+      <x>255</x>
       <y>120</y>
-      <width>60</width>
+      <width>100</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -1212,7 +1212,7 @@
       <name>Label</name>
       <text>Trigger Mode</text>
       <y>144</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -1234,9 +1234,9 @@
     <widget type="combo" version="2.0.0">
       <name>ComboBox</name>
       <pv_name>$(P)$(R)TriggerMode</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>144</y>
-      <width>60</width>
+      <width>100</width>
       <height>20</height>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
@@ -1254,9 +1254,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)TriggerMode_RBV</pv_name>
-      <x>188</x>
+      <x>255</x>
       <y>144</y>
-      <width>60</width>
+      <width>100</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -1280,7 +1280,7 @@
       <name>Label</name>
       <text>Detector State</text>
       <y>168</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -1302,9 +1302,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)DetectorState_RBV</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>168</y>
-      <width>124</width>
+      <width>205</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -1328,7 +1328,7 @@
       <name>Label</name>
       <text>Status Message</text>
       <y>192</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -1350,9 +1350,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)StatusMessage_RBV</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>192</y>
-      <width>124</width>
+      <width>205</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -1377,7 +1377,7 @@
       <name>Label</name>
       <text>Time Remaining</text>
       <y>216</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -1399,9 +1399,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)TimeRemaining_RBV</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>216</y>
-      <width>124</width>
+      <width>205</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -1425,7 +1425,7 @@
       <name>Label</name>
       <text>Num Queued Arrays</text>
       <y>240</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -1447,9 +1447,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)NumQueuedArrays</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>240</y>
-      <width>124</width>
+      <width>205</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -1473,7 +1473,7 @@
       <name>Label</name>
       <text>Wait For Plugins</text>
       <y>264</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -1495,9 +1495,9 @@
     <widget type="choice" version="2.0.0">
       <name>ToggleButton</name>
       <pv_name>$(P)$(R)WaitForPlugins</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>264</y>
-      <width>124</width>
+      <width>205</width>
       <height>20</height>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
@@ -1524,7 +1524,7 @@
       <name>Label</name>
       <text>Acquire</text>
       <y>288</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -1546,9 +1546,9 @@
     <widget type="choice" version="2.0.0">
       <name>ToggleButton</name>
       <pv_name>$(P)$(R)Acquire</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>288</y>
-      <width>60</width>
+      <width>100</width>
       <height>20</height>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
@@ -1574,7 +1574,7 @@
     <widget type="led" version="2.0.0">
       <name>LED</name>
       <pv_name>$(P)$(R)Acquire_RBV</pv_name>
-      <x>208</x>
+      <x>295</x>
       <y>288</y>
       <off_color use_class="true">
         <color red="237" green="237" blue="237">
@@ -1593,7 +1593,7 @@
       <name>Label</name>
       <text>Array Counter</text>
       <y>312</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -1615,9 +1615,9 @@
     <widget type="textentry" version="3.0.0">
       <name>TextEntry</name>
       <pv_name>$(P)$(R)ArrayCounter</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>312</y>
-      <width>60</width>
+      <width>100</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -1644,9 +1644,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)ArrayCounter_RBV</pv_name>
-      <x>188</x>
+      <x>255</x>
       <y>312</y>
-      <width>60</width>
+      <width>100</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -1670,7 +1670,7 @@
       <name>Label</name>
       <text>Array Callbacks</text>
       <y>336</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -1692,9 +1692,9 @@
     <widget type="choice" version="2.0.0">
       <name>ToggleButton</name>
       <pv_name>$(P)$(R)ArrayCallbacks</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>336</y>
-      <width>60</width>
+      <width>100</width>
       <height>20</height>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
@@ -1720,7 +1720,7 @@
     <widget type="led" version="2.0.0">
       <name>LED</name>
       <pv_name>$(P)$(R)ArrayCallbacks_RBV</pv_name>
-      <x>208</x>
+      <x>295</x>
       <y>336</y>
       <off_color use_class="true">
         <color red="237" green="237" blue="237">
@@ -1738,9 +1738,9 @@
   </widget>
   <widget type="group" version="3.0.0">
     <name>AD Epics Shutter</name>
-    <x>4</x>
+    <x>5</x>
     <y>804</y>
-    <width>282</width>
+    <width>396</width>
     <height>54</height>
     <style use_class="true">0</style>
     <font use_class="true">
@@ -1759,7 +1759,7 @@
     <widget type="label" version="2.0.0">
       <name>Label</name>
       <text>Shutter Status</text>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -1781,7 +1781,7 @@
     <widget type="led" version="2.0.0">
       <name>LED</name>
       <pv_name>$(P)$(R)ShutterStatus_RBV</pv_name>
-      <x>176</x>
+      <x>244</x>
       <off_color use_class="true">
         <color red="237" green="237" blue="237">
         </color>
@@ -1798,9 +1798,9 @@
   </widget>
   <widget type="group" version="3.0.0">
     <name>AD Readout</name>
-    <x>290</x>
+    <x>406</x>
     <y>30</y>
-    <width>282</width>
+    <width>396</width>
     <height>414</height>
     <style use_class="true">0</style>
     <font use_class="true">
@@ -1819,7 +1819,7 @@
     <widget type="label" version="2.0.0">
       <name>Label</name>
       <text>Max Size X</text>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -1841,8 +1841,8 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)MaxSizeX_RBV</pv_name>
-      <x>124</x>
-      <width>124</width>
+      <x>150</x>
+      <width>205</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -1866,7 +1866,7 @@
       <name>Label</name>
       <text>Max Size Y</text>
       <y>24</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -1888,9 +1888,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)MaxSizeY_RBV</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>24</y>
-      <width>124</width>
+      <width>205</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -1914,7 +1914,7 @@
       <name>Label</name>
       <text>Bin X</text>
       <y>48</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -1936,9 +1936,9 @@
     <widget type="textentry" version="3.0.0">
       <name>TextEntry</name>
       <pv_name>$(P)$(R)BinX</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>48</y>
-      <width>60</width>
+      <width>100</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -1965,9 +1965,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)BinX_RBV</pv_name>
-      <x>188</x>
+      <x>255</x>
       <y>48</y>
-      <width>60</width>
+      <width>100</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -1991,7 +1991,7 @@
       <name>Label</name>
       <text>Bin Y</text>
       <y>72</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -2013,9 +2013,9 @@
     <widget type="textentry" version="3.0.0">
       <name>TextEntry</name>
       <pv_name>$(P)$(R)BinY</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>72</y>
-      <width>60</width>
+      <width>100</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -2042,9 +2042,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)BinY_RBV</pv_name>
-      <x>188</x>
+      <x>255</x>
       <y>72</y>
-      <width>60</width>
+      <width>100</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -2068,7 +2068,7 @@
       <name>Label</name>
       <text>Min Y</text>
       <y>96</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -2090,9 +2090,9 @@
     <widget type="textentry" version="3.0.0">
       <name>TextEntry</name>
       <pv_name>$(P)$(R)MinY</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>96</y>
-      <width>60</width>
+      <width>100</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -2119,9 +2119,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)MinY_RBV</pv_name>
-      <x>188</x>
+      <x>255</x>
       <y>96</y>
-      <width>60</width>
+      <width>100</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -2145,7 +2145,7 @@
       <name>Label</name>
       <text>Min X</text>
       <y>120</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -2167,9 +2167,9 @@
     <widget type="textentry" version="3.0.0">
       <name>TextEntry</name>
       <pv_name>$(P)$(R)MinX</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>120</y>
-      <width>60</width>
+      <width>100</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -2196,9 +2196,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)MinX_RBV</pv_name>
-      <x>188</x>
+      <x>255</x>
       <y>120</y>
-      <width>60</width>
+      <width>100</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -2222,7 +2222,7 @@
       <name>Label</name>
       <text>Reverse X</text>
       <y>144</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -2244,9 +2244,9 @@
     <widget type="choice" version="2.0.0">
       <name>ToggleButton</name>
       <pv_name>$(P)$(R)ReverseX</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>144</y>
-      <width>64</width>
+      <width>100</width>
       <height>20</height>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
@@ -2272,7 +2272,7 @@
     <widget type="led" version="2.0.0">
       <name>LED</name>
       <pv_name>$(P)$(R)ReverseX_RBV</pv_name>
-      <x>208</x>
+      <x>295</x>
       <y>144</y>
       <off_color use_class="true">
         <color red="237" green="237" blue="237">
@@ -2291,7 +2291,7 @@
       <name>Label</name>
       <text>Reverse Y</text>
       <y>168</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -2313,9 +2313,9 @@
     <widget type="choice" version="2.0.0">
       <name>ToggleButton</name>
       <pv_name>$(P)$(R)ReverseY</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>168</y>
-      <width>64</width>
+      <width>100</width>
       <height>20</height>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
@@ -2341,7 +2341,7 @@
     <widget type="led" version="2.0.0">
       <name>LED</name>
       <pv_name>$(P)$(R)ReverseY_RBV</pv_name>
-      <x>208</x>
+      <x>295</x>
       <y>168</y>
       <off_color use_class="true">
         <color red="237" green="237" blue="237">
@@ -2360,7 +2360,7 @@
       <name>Label</name>
       <text>Size X</text>
       <y>192</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -2382,9 +2382,9 @@
     <widget type="textentry" version="3.0.0">
       <name>TextEntry</name>
       <pv_name>$(P)$(R)SizeX</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>192</y>
-      <width>60</width>
+      <width>100</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -2411,9 +2411,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)SizeX_RBV</pv_name>
-      <x>188</x>
+      <x>255</x>
       <y>192</y>
-      <width>60</width>
+      <width>100</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -2437,7 +2437,7 @@
       <name>Label</name>
       <text>Size Y</text>
       <y>216</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -2459,9 +2459,9 @@
     <widget type="textentry" version="3.0.0">
       <name>TextEntry</name>
       <pv_name>$(P)$(R)SizeY</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>216</y>
-      <width>60</width>
+      <width>100</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -2488,9 +2488,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)SizeY_RBV</pv_name>
-      <x>188</x>
+      <x>255</x>
       <y>216</y>
-      <width>60</width>
+      <width>100</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -2514,7 +2514,7 @@
       <name>Label</name>
       <text>Gain</text>
       <y>240</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -2536,9 +2536,9 @@
     <widget type="textentry" version="3.0.0">
       <name>TextEntry</name>
       <pv_name>$(P)$(R)Gain</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>240</y>
-      <width>60</width>
+      <width>100</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -2565,9 +2565,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)Gain_RBV</pv_name>
-      <x>188</x>
+      <x>255</x>
       <y>240</y>
-      <width>60</width>
+      <width>100</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -2591,7 +2591,7 @@
       <name>Label</name>
       <text>Array Size X</text>
       <y>264</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -2613,9 +2613,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)ArraySizeX_RBV</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>264</y>
-      <width>124</width>
+      <width>205</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -2639,7 +2639,7 @@
       <name>Label</name>
       <text>Array Size Y</text>
       <y>288</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -2661,9 +2661,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)ArraySizeY_RBV</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>288</y>
-      <width>124</width>
+      <width>205</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -2687,7 +2687,7 @@
       <name>Label</name>
       <text>Array Size</text>
       <y>312</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -2709,9 +2709,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)ArraySize_RBV</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>312</y>
-      <width>124</width>
+      <width>205</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -2735,7 +2735,7 @@
       <name>Label</name>
       <text>Data Type</text>
       <y>336</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -2757,9 +2757,9 @@
     <widget type="combo" version="2.0.0">
       <name>ComboBox</name>
       <pv_name>$(P)$(R)DataType</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>336</y>
-      <width>60</width>
+      <width>100</width>
       <height>20</height>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
@@ -2777,9 +2777,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)DataType_RBV</pv_name>
-      <x>188</x>
+      <x>255</x>
       <y>336</y>
-      <width>60</width>
+      <width>100</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -2803,7 +2803,7 @@
       <name>Label</name>
       <text>Color Mode</text>
       <y>360</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -2825,9 +2825,9 @@
     <widget type="combo" version="2.0.0">
       <name>ComboBox</name>
       <pv_name>$(P)$(R)ColorMode</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>360</y>
-      <width>60</width>
+      <width>100</width>
       <height>20</height>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
@@ -2845,9 +2845,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)ColorMode_RBV</pv_name>
-      <x>188</x>
+      <x>255</x>
       <y>360</y>
-      <width>60</width>
+      <width>100</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -2870,9 +2870,9 @@
   </widget>
   <widget type="group" version="3.0.0">
     <name>AD Shutter</name>
-    <x>290</x>
+    <x>406</x>
     <y>448</y>
-    <width>282</width>
+    <width>396</width>
     <height>126</height>
     <style use_class="true">0</style>
     <font use_class="true">
@@ -2891,7 +2891,7 @@
     <widget type="label" version="2.0.0">
       <name>Label</name>
       <text>Shutter Mode</text>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -2913,8 +2913,8 @@
     <widget type="combo" version="2.0.0">
       <name>ComboBox</name>
       <pv_name>$(P)$(R)ShutterMode</pv_name>
-      <x>124</x>
-      <width>60</width>
+      <x>150</x>
+      <width>100</width>
       <height>20</height>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
@@ -2932,8 +2932,8 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)ShutterMode_RBV</pv_name>
-      <x>188</x>
-      <width>60</width>
+      <x>255</x>
+      <width>100</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -2957,7 +2957,7 @@
       <name>Label</name>
       <text>Shutter Control</text>
       <y>24</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -2979,9 +2979,9 @@
     <widget type="choice" version="2.0.0">
       <name>ToggleButton</name>
       <pv_name>$(P)$(R)ShutterControl</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>24</y>
-      <width>64</width>
+      <width>100</width>
       <height>20</height>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
@@ -3007,7 +3007,7 @@
     <widget type="led" version="2.0.0">
       <name>LED</name>
       <pv_name>$(P)$(R)ShutterControl_RBV</pv_name>
-      <x>208</x>
+      <x>295</x>
       <y>24</y>
       <off_color use_class="true">
         <color red="237" green="237" blue="237">
@@ -3026,7 +3026,7 @@
       <name>Label</name>
       <text>Shutter Open Delay</text>
       <y>48</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -3048,9 +3048,9 @@
     <widget type="textentry" version="3.0.0">
       <name>TextEntry</name>
       <pv_name>$(P)$(R)ShutterOpenDelay</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>48</y>
-      <width>60</width>
+      <width>100</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -3077,9 +3077,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)ShutterOpenDelay_RBV</pv_name>
-      <x>188</x>
+      <x>255</x>
       <y>48</y>
-      <width>60</width>
+      <width>100</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -3103,7 +3103,7 @@
       <name>Label</name>
       <text>Shutter Close Delay</text>
       <y>72</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -3125,9 +3125,9 @@
     <widget type="textentry" version="3.0.0">
       <name>TextEntry</name>
       <pv_name>$(P)$(R)ShutterCloseDelay</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>72</y>
-      <width>60</width>
+      <width>100</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -3154,9 +3154,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)ShutterCloseDelay_RBV</pv_name>
-      <x>188</x>
+      <x>255</x>
       <y>72</y>
-      <width>60</width>
+      <width>100</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -3179,9 +3179,9 @@
   </widget>
   <widget type="group" version="3.0.0">
     <name>ADDriver Ungrouped</name>
-    <x>290</x>
+    <x>406</x>
     <y>578</y>
-    <width>282</width>
+    <width>396</width>
     <height>222</height>
     <style use_class="true">0</style>
     <font use_class="true">
@@ -3200,7 +3200,7 @@
     <widget type="label" version="2.0.0">
       <name>Label</name>
       <text>Read Status</text>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -3222,8 +3222,8 @@
     <widget type="choice" version="2.0.0">
       <name>ToggleButton</name>
       <pv_name>$(P)$(R)ReadStatus</pv_name>
-      <x>124</x>
-      <width>124</width>
+      <x>150</x>
+      <width>205</width>
       <height>20</height>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
@@ -3250,7 +3250,7 @@
       <name>Label</name>
       <text>Num Exposures Counter</text>
       <y>24</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -3272,9 +3272,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)NumExposuresCounter_RBV</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>24</y>
-      <width>124</width>
+      <width>205</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -3298,7 +3298,7 @@
       <name>Label</name>
       <text>String To Server</text>
       <y>48</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -3320,9 +3320,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)StringToServer_RBV</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>48</y>
-      <width>124</width>
+      <width>205</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -3347,7 +3347,7 @@
       <name>Label</name>
       <text>String From Server</text>
       <y>72</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -3369,9 +3369,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)StringFromServer_RBV</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>72</y>
-      <width>124</width>
+      <width>205</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -3396,7 +3396,7 @@
       <name>Label</name>
       <text>Shutter Control EPICS</text>
       <y>96</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -3418,7 +3418,7 @@
     <widget type="led" version="2.0.0">
       <name>LED</name>
       <pv_name>$(P)$(R)ShutterControlEPICS</pv_name>
-      <x>176</x>
+      <x>244</x>
       <y>96</y>
       <off_color use_class="true">
         <color red="237" green="237" blue="237">
@@ -3437,7 +3437,7 @@
       <name>Label</name>
       <text>Temperature Actual</text>
       <y>120</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -3459,9 +3459,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)TemperatureActual</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>120</y>
-      <width>124</width>
+      <width>205</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -3485,7 +3485,7 @@
       <name>Label</name>
       <text>Frame Type</text>
       <y>144</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -3507,9 +3507,9 @@
     <widget type="combo" version="2.0.0">
       <name>ComboBox</name>
       <pv_name>$(P)$(R)FrameType</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>144</y>
-      <width>60</width>
+      <width>100</width>
       <height>20</height>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
@@ -3527,9 +3527,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)FrameType_RBV</pv_name>
-      <x>188</x>
+      <x>255</x>
       <y>144</y>
-      <width>60</width>
+      <width>100</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -3553,7 +3553,7 @@
       <name>Label</name>
       <text>Temperature</text>
       <y>168</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -3575,9 +3575,9 @@
     <widget type="textentry" version="3.0.0">
       <name>TextEntry</name>
       <pv_name>$(P)$(R)Temperature</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>168</y>
-      <width>60</width>
+      <width>100</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -3604,9 +3604,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)Temperature_RBV</pv_name>
-      <x>188</x>
+      <x>255</x>
       <y>168</y>
-      <width>60</width>
+      <width>100</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -3629,9 +3629,9 @@
   </widget>
   <widget type="group" version="3.0.0">
     <name>AD Attr File</name>
-    <x>290</x>
+    <x>406</x>
     <y>804</y>
-    <width>282</width>
+    <width>396</width>
     <height>102</height>
     <style use_class="true">0</style>
     <font use_class="true">
@@ -3650,7 +3650,7 @@
     <widget type="label" version="2.0.0">
       <name>Label</name>
       <text>ND Attributes File</text>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -3672,8 +3672,8 @@
     <widget type="textentry" version="3.0.0">
       <name>TextEntry</name>
       <pv_name>$(P)$(R)NDAttributesFile</pv_name>
-      <x>124</x>
-      <width>124</width>
+      <x>150</x>
+      <width>205</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -3702,7 +3702,7 @@
       <name>Label</name>
       <text>ND Attributes Macros</text>
       <y>24</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -3724,9 +3724,9 @@
     <widget type="textentry" version="3.0.0">
       <name>TextEntry</name>
       <pv_name>$(P)$(R)NDAttributesMacros</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>24</y>
-      <width>124</width>
+      <width>205</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -3755,7 +3755,7 @@
       <name>Label</name>
       <text>ND Attributes Status</text>
       <y>48</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -3777,9 +3777,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)NDAttributesStatus</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>48</y>
-      <width>124</width>
+      <width>205</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -3802,9 +3802,9 @@
   </widget>
   <widget type="group" version="3.0.0">
     <name>AD Buffers</name>
-    <x>576</x>
+    <x>807</x>
     <y>30</y>
-    <width>282</width>
+    <width>396</width>
     <height>222</height>
     <style use_class="true">0</style>
     <font use_class="true">
@@ -3823,7 +3823,7 @@
     <widget type="label" version="2.0.0">
       <name>Label</name>
       <text>Pre Alloc Buffers</text>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -3845,8 +3845,8 @@
     <widget type="choice" version="2.0.0">
       <name>ToggleButton</name>
       <pv_name>$(P)$(R)PreAllocBuffers</pv_name>
-      <x>124</x>
-      <width>124</width>
+      <x>150</x>
+      <width>205</width>
       <height>20</height>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
@@ -3873,7 +3873,7 @@
       <name>Label</name>
       <text>Num Pre Alloc Buffers</text>
       <y>24</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -3895,9 +3895,9 @@
     <widget type="textentry" version="3.0.0">
       <name>TextEntry</name>
       <pv_name>$(P)$(R)NumPreAllocBuffers</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>24</y>
-      <width>60</width>
+      <width>100</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -3924,9 +3924,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)NumPreAllocBuffers_RBV</pv_name>
-      <x>188</x>
+      <x>255</x>
       <y>24</y>
-      <width>60</width>
+      <width>100</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -3950,7 +3950,7 @@
       <name>Label</name>
       <text>Pool Alloc Buffers</text>
       <y>48</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -3972,9 +3972,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)PoolAllocBuffers</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>48</y>
-      <width>124</width>
+      <width>205</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -3998,7 +3998,7 @@
       <name>Label</name>
       <text>Pool Free Buffers</text>
       <y>72</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -4020,9 +4020,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)PoolFreeBuffers</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>72</y>
-      <width>124</width>
+      <width>205</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -4046,7 +4046,7 @@
       <name>Label</name>
       <text>Pool Max Mem</text>
       <y>96</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -4068,9 +4068,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)PoolMaxMem</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>96</y>
-      <width>124</width>
+      <width>205</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -4094,7 +4094,7 @@
       <name>Label</name>
       <text>Pool Used Mem</text>
       <y>120</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -4116,9 +4116,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)PoolUsedMem</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>120</y>
-      <width>124</width>
+      <width>205</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -4142,7 +4142,7 @@
       <name>Label</name>
       <text>Pool Poll Stats</text>
       <y>144</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -4164,9 +4164,9 @@
     <widget type="choice" version="2.0.0">
       <name>ToggleButton</name>
       <pv_name>$(P)$(R)PoolPollStats</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>144</y>
-      <width>124</width>
+      <width>205</width>
       <height>20</height>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
@@ -4193,7 +4193,7 @@
       <name>Label</name>
       <text>Empty Free List</text>
       <y>168</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -4215,9 +4215,9 @@
     <widget type="choice" version="2.0.0">
       <name>ToggleButton</name>
       <pv_name>$(P)$(R)EmptyFreeList</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>168</y>
-      <width>124</width>
+      <width>205</width>
       <height>20</height>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
@@ -4243,9 +4243,9 @@
   </widget>
   <widget type="group" version="3.0.0">
     <name>AD Plugins</name>
-    <x>576</x>
+    <x>807</x>
     <y>256</y>
-    <width>282</width>
+    <width>396</width>
     <height>54</height>
     <style use_class="true">0</style>
     <font use_class="true">
@@ -4264,7 +4264,7 @@
     <widget type="label" version="2.0.0">
       <name>Label</name>
       <text>Codec</text>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -4286,8 +4286,8 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)Codec_RBV</pv_name>
-      <x>124</x>
-      <width>124</width>
+      <x>150</x>
+      <width>205</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -4310,9 +4310,9 @@
   </widget>
   <widget type="group" version="3.0.0">
     <name>AD Setup</name>
-    <x>576</x>
+    <x>807</x>
     <y>314</y>
-    <width>282</width>
+    <width>396</width>
     <height>222</height>
     <style use_class="true">0</style>
     <font use_class="true">
@@ -4331,7 +4331,7 @@
     <widget type="label" version="2.0.0">
       <name>Label</name>
       <text>Port Name</text>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -4353,8 +4353,8 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)PortName_RBV</pv_name>
-      <x>124</x>
-      <width>124</width>
+      <x>150</x>
+      <width>205</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -4378,7 +4378,7 @@
       <name>Label</name>
       <text>Manufacturer</text>
       <y>24</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -4400,9 +4400,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)Manufacturer_RBV</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>24</y>
-      <width>124</width>
+      <width>205</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -4426,7 +4426,7 @@
       <name>Label</name>
       <text>Model</text>
       <y>48</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -4448,9 +4448,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)Model_RBV</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>48</y>
-      <width>124</width>
+      <width>205</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -4474,7 +4474,7 @@
       <name>Label</name>
       <text>Serial Number</text>
       <y>72</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -4496,9 +4496,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)SerialNumber_RBV</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>72</y>
-      <width>124</width>
+      <width>205</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -4522,7 +4522,7 @@
       <name>Label</name>
       <text>Firmware Version</text>
       <y>96</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -4544,9 +4544,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)FirmwareVersion_RBV</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>96</y>
-      <width>124</width>
+      <width>205</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -4570,7 +4570,7 @@
       <name>Label</name>
       <text>SDK Version</text>
       <y>120</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -4592,9 +4592,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)SDKVersion_RBV</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>120</y>
-      <width>124</width>
+      <width>205</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -4618,7 +4618,7 @@
       <name>Label</name>
       <text>Driver Version</text>
       <y>144</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -4640,9 +4640,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)DriverVersion_RBV</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>144</y>
-      <width>124</width>
+      <width>205</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -4666,7 +4666,7 @@
       <name>Label</name>
       <text>AD Core Version</text>
       <y>168</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -4688,9 +4688,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)ADCoreVersion_RBV</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>168</y>
-      <width>124</width>
+      <width>205</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -4713,9 +4713,9 @@
   </widget>
   <widget type="group" version="3.0.0">
     <name>ND Circular Buff</name>
-    <x>576</x>
+    <x>807</x>
     <y>540</y>
-    <width>282</width>
+    <width>396</width>
     <height>126</height>
     <style use_class="true">0</style>
     <font use_class="true">
@@ -4734,7 +4734,7 @@
     <widget type="label" version="2.0.0">
       <name>Label</name>
       <text>N Dimensions</text>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -4756,8 +4756,8 @@
     <widget type="textentry" version="3.0.0">
       <name>TextEntry</name>
       <pv_name>$(P)$(R)NDimensions</pv_name>
-      <x>124</x>
-      <width>60</width>
+      <x>150</x>
+      <width>100</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -4784,8 +4784,8 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)NDimensions_RBV</pv_name>
-      <x>188</x>
-      <width>60</width>
+      <x>255</x>
+      <width>100</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -4809,7 +4809,7 @@
       <name>Label</name>
       <text>Dimensions</text>
       <y>24</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -4831,9 +4831,9 @@
     <widget type="textentry" version="3.0.0">
       <name>TextEntry</name>
       <pv_name>$(P)$(R)Dimensions</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>24</y>
-      <width>60</width>
+      <width>100</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -4860,9 +4860,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)Dimensions_RBV</pv_name>
-      <x>188</x>
+      <x>255</x>
       <y>24</y>
-      <width>60</width>
+      <width>100</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -4886,7 +4886,7 @@
       <name>Label</name>
       <text>Unique Id</text>
       <y>48</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -4908,9 +4908,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)UniqueId_RBV</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>48</y>
-      <width>124</width>
+      <width>205</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -4934,7 +4934,7 @@
       <name>Label</name>
       <text>Time Stamp</text>
       <y>72</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -4956,9 +4956,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)TimeStamp_RBV</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>72</y>
-      <width>124</width>
+      <width>205</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -4981,9 +4981,9 @@
   </widget>
   <widget type="group" version="3.0.0">
     <name>ND Plugin Base Full</name>
-    <x>576</x>
+    <x>807</x>
     <y>670</y>
-    <width>282</width>
+    <width>396</width>
     <height>78</height>
     <style use_class="true">0</style>
     <font use_class="true">
@@ -5002,7 +5002,7 @@
     <widget type="label" version="2.0.0">
       <name>Label</name>
       <text>Compressed Size</text>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -5024,8 +5024,8 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)CompressedSize_RBV</pv_name>
-      <x>124</x>
-      <width>124</width>
+      <x>150</x>
+      <width>205</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -5049,7 +5049,7 @@
       <name>Label</name>
       <text>Bayer Pattern</text>
       <y>24</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -5071,9 +5071,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)BayerPattern_RBV</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>24</y>
-      <width>124</width>
+      <width>205</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -5096,9 +5096,9 @@
   </widget>
   <widget type="group" version="3.0.0">
     <name>NDROI</name>
-    <x>576</x>
+    <x>807</x>
     <y>752</y>
-    <width>282</width>
+    <width>396</width>
     <height>54</height>
     <style use_class="true">0</style>
     <font use_class="true">
@@ -5117,7 +5117,7 @@
     <widget type="label" version="2.0.0">
       <name>Label</name>
       <text>Array Size Z</text>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -5139,8 +5139,8 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)ArraySizeZ_RBV</pv_name>
-      <x>124</x>
-      <width>124</width>
+      <x>150</x>
+      <width>205</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -5163,9 +5163,9 @@
   </widget>
   <widget type="group" version="3.0.0">
     <name>NDArrayBase Ungrouped</name>
-    <x>576</x>
+    <x>807</x>
     <y>810</y>
-    <width>282</width>
+    <width>396</width>
     <height>102</height>
     <style use_class="true">0</style>
     <font use_class="true">
@@ -5184,7 +5184,7 @@
     <widget type="label" version="2.0.0">
       <name>Label</name>
       <text>Acquire Busy CB</text>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -5206,7 +5206,7 @@
     <widget type="led" version="2.0.0">
       <name>LED</name>
       <pv_name>$(P)$(R)AcquireBusyCB</pv_name>
-      <x>176</x>
+      <x>242</x>
       <off_color use_class="true">
         <color red="237" green="237" blue="237">
         </color>
@@ -5224,7 +5224,7 @@
       <name>Label</name>
       <text>Epics TS Sec</text>
       <y>24</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -5246,9 +5246,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)EpicsTSSec_RBV</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>24</y>
-      <width>124</width>
+      <width>205</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -5272,7 +5272,7 @@
       <name>Label</name>
       <text>Epics TS Nsec</text>
       <y>48</y>
-      <width>120</width>
+      <width>150</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>
@@ -5294,9 +5294,9 @@
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate</name>
       <pv_name>$(P)$(R)EpicsTSNsec_RBV</pv_name>
-      <x>124</x>
+      <x>150</x>
       <y>48</y>
-      <width>124</width>
+      <width>205</width>
       <font use_class="true">
         <font family="Arial" style="REGULAR" size="14.0">
         </font>


### PR DESCRIPTION
Changed width and x values only,  see result:

<img width="1095" height="889" alt="Screenshot from 2026-01-21 16-48-49" src="https://github.com/user-attachments/assets/2c4eb1a3-b5c1-438f-ad6c-2c5b7dbb2536" />
