### PR TITLE
changed aduvc summary screen suffix to DRV

### DIFF
--- a/bob/ADUVC/ADUVC_summary.bob
+++ b/bob/ADUVC/ADUVC_summary.bob
@@ -55,7 +55,7 @@
     </widget>
     <widget type="textupdate" version="2.0.0">
       <name>ArrayCounter_RBV</name>
-      <pv_name>$(P):CAM:ArrayCounter_RBV</pv_name>
+      <pv_name>$(P):DRV:ArrayCounter_RBV</pv_name>
       <x>140</x>
       <y>25</y>
       <width>235</width>
@@ -76,7 +76,7 @@
     </widget>
     <widget type="byte_monitor" version="2.0.0">
       <name>Acquire</name>
-      <pv_name>$(P):CAM:Acquire</pv_name>
+      <pv_name>$(P):DRV:Acquire</pv_name>
       <x>308</x>
       <width>20</width>
       <numBits>1</numBits>
@@ -91,7 +91,7 @@
     </widget>
     <widget type="byte_monitor" version="2.0.0">
       <name>Array Callbacks</name>
-      <pv_name>$(P):CAM:ArrayCallbacks_RBV</pv_name>
+      <pv_name>$(P):DRV:ArrayCallbacks_RBV</pv_name>
       <x>308</x>
       <y>50</y>
       <width>20</width>
@@ -107,7 +107,7 @@
     </widget>
     <widget type="choice" version="2.0.0">
       <name>Array Callbacks_1</name>
-      <pv_name>$(P):CAM:ArrayCallbacks</pv_name>
+      <pv_name>$(P):DRV:ArrayCallbacks</pv_name>
       <x>140</x>
       <y>50</y>
       <width>126</width>
@@ -347,7 +347,7 @@
     </widget>
     <widget type="textupdate" version="2.0.0">
       <name>Acuqire Time</name>
-      <pv_name>$(P):CAM:AcquireTime_RBV</pv_name>
+      <pv_name>$(P):DRV:AcquireTime_RBV</pv_name>
       <x>260</x>
       <y>75</y>
       <width>115</width>
@@ -368,7 +368,7 @@
     </widget>
     <widget type="textupdate" version="2.0.0">
       <name>Acquire Period_RBV</name>
-      <pv_name>$(P):CAM:AcquirePeriod_RBV</pv_name>
+      <pv_name>$(P):DRV:AcquirePeriod_RBV</pv_name>
       <x>260</x>
       <y>100</y>
       <width>115</width>
@@ -389,7 +389,7 @@
     </widget>
     <widget type="textupdate" version="2.0.0">
       <name>NUm Images_RBV</name>
-      <pv_name>$(P):CAM:NumImages</pv_name>
+      <pv_name>$(P):DRV:NumImages</pv_name>
       <x>260</x>
       <y>150</y>
       <width>115</width>
@@ -410,7 +410,7 @@
     </widget>
     <widget type="textupdate" version="2.0.0">
       <name>Num Exposures_RBV</name>
-      <pv_name>$(P):CAM:NumExposures_RBV</pv_name>
+      <pv_name>$(P):DRV:NumExposures_RBV</pv_name>
       <x>260</x>
       <y>175</y>
       <width>115</width>
@@ -431,7 +431,7 @@
     </widget>
     <widget type="combo" version="2.0.0">
       <name>Image Mode</name>
-      <pv_name>$(P):CAM:ImageMode</pv_name>
+      <pv_name>$(P):DRV:ImageMode</pv_name>
       <x>140</x>
       <y>200</y>
       <width>115</width>
@@ -459,7 +459,7 @@
     </widget>
     <widget type="choice" version="2.0.0">
       <name>Acquire_1</name>
-      <pv_name>$(P):CAM:Acquire</pv_name>
+      <pv_name>$(P):DRV:Acquire</pv_name>
       <x>140</x>
       <width>126</width>
       <height>20</height>
@@ -646,7 +646,7 @@
     </widget>
     <widget type="textentry" version="3.0.0">
       <name>Acquire Time</name>
-      <pv_name>$(P):CAM:AcquireTime</pv_name>
+      <pv_name>$(P):DRV:AcquireTime</pv_name>
       <x>140</x>
       <y>75</y>
       <width>115</width>
@@ -667,7 +667,7 @@
     </widget>
     <widget type="textentry" version="3.0.0">
       <name>Acquire Period</name>
-      <pv_name>$(P):CAM:AcquirePeriod</pv_name>
+      <pv_name>$(P):DRV:AcquirePeriod</pv_name>
       <x>140</x>
       <y>100</y>
       <width>115</width>
@@ -688,7 +688,7 @@
     </widget>
     <widget type="textentry" version="3.0.0">
       <name>NumImages</name>
-      <pv_name>$(P):CAM:NumImages_RBV</pv_name>
+      <pv_name>$(P):DRV:NumImages_RBV</pv_name>
       <x>140</x>
       <y>150</y>
       <width>115</width>
@@ -709,7 +709,7 @@
     </widget>
     <widget type="textentry" version="3.0.0">
       <name>Num Exposures</name>
-      <pv_name>$(P):CAM:NumExposures</pv_name>
+      <pv_name>$(P):DRV:NumExposures</pv_name>
       <x>140</x>
       <y>175</y>
       <width>115</width>
@@ -730,7 +730,7 @@
     </widget>
     <widget type="textupdate" version="2.0.0">
       <name>Image mode</name>
-      <pv_name>$(P):CAM:ImageMode_RBV</pv_name>
+      <pv_name>$(P):DRV:ImageMode_RBV</pv_name>
       <x>260</x>
       <y>200</y>
       <width>115</width>
@@ -751,7 +751,7 @@
     </widget>
     <widget type="textupdate" version="2.0.0">
       <name>Detector State</name>
-      <pv_name>$(P):CAM:DetectorState_RBV</pv_name>
+      <pv_name>$(P):DRV:DetectorState_RBV</pv_name>
       <x>140</x>
       <y>250</y>
       <width>235</width>
@@ -772,7 +772,7 @@
     </widget>
     <widget type="textupdate" version="2.0.0">
       <name>TextUpdate_13</name>
-      <pv_name>$(P):CAM:StatusMessage_RBV</pv_name>
+      <pv_name>$(P):DRV:StatusMessage_RBV</pv_name>
       <x>141</x>
       <y>275</y>
       <width>235</width>
@@ -814,7 +814,7 @@
     </widget>
     <widget type="textentry" version="3.0.0">
       <name>Gain</name>
-      <pv_name>$(P):CAM:Gain</pv_name>
+      <pv_name>$(P):DRV:Gain</pv_name>
       <x>139</x>
       <y>225</y>
       <width>115</width>
@@ -835,7 +835,7 @@
     </widget>
     <widget type="textupdate" version="2.0.0">
       <name>Gain_RBV</name>
-      <pv_name>$(P):CAM:Gain_RBV</pv_name>
+      <pv_name>$(P):DRV:Gain_RBV</pv_name>
       <x>259</x>
       <y>225</y>
       <width>115</width>
@@ -872,7 +872,7 @@
     </widget>
     <widget type="textupdate" version="2.0.0">
       <name>ArrayCounter_RBV_1</name>
-      <pv_name>$(P):CAM:NumImagesCounter_RBV</pv_name>
+      <pv_name>$(P):DRV:NumImagesCounter_RBV</pv_name>
       <x>140</x>
       <y>125</y>
       <width>235</width>


### PR DESCRIPTION
will be using DRV instead of CAM in future, currently just ADUVC devices have :DRV: iin ioc.yaml